### PR TITLE
Add netprivacy module configuration

### DIFF
--- a/etc/calamares/modules/netprivacy.conf
+++ b/etc/calamares/modules/netprivacy.conf
@@ -1,0 +1,11 @@
+# netprivacy module configuration for Kicksecure
+# Privacy-focused defaults for MAC spoofing and IPv6
+---
+
+# MAC policy: 0=disabled, 1=random, 2=vendor, 3=fixed
+# Default to random for maximum privacy
+macPolicy: 1
+
+# IPv6 mode: 0=standard, 1=privacy extensions, 2=disabled
+# Default to privacy extensions
+ipv6Mode: 1

--- a/etc/calamares/settings.conf.dist
+++ b/etc/calamares/settings.conf.dist
@@ -33,6 +33,7 @@ sequence:
 - show:
   - welcome
   - locale
+  - netprivacy
   - keyboard
   - partition
   - summary


### PR DESCRIPTION
Adds configuration for the netprivacy Calamares module, which provides MAC address spoofing and IPv6 privacy options during installation.

Changes:
- Added netprivacy to settings.conf.dist sequence after locale
- Created netprivacy.conf with privacy-focused defaults (random MAC, IPv6 privacy extensions)

Requires upstream Calamares: https://codeberg.org/Calamares/calamares/pulls/2479

<img width="1034" height="708" alt="Screenshot_2026-01-14_16-34-39" src="https://github.com/user-attachments/assets/1e3d0853-dd9f-4439-bbf0-79c4eafeade3" />
